### PR TITLE
add import for Dict used in `compute_gradient_of_variables`

### DIFF
--- a/python/needle/autograd.py
+++ b/python/needle/autograd.py
@@ -1,6 +1,6 @@
 """Core data structures."""
 import needle
-from typing import List, Optional, NamedTuple, Tuple, Union
+from typing import List, Optional, NamedTuple, Tuple, Union, Dict
 from collections import namedtuple
 import numpy
 


### PR DESCRIPTION
You may miss an import for `Dict` in `python/needle/autograd.py`, line 392.
<img width="811" alt="image" src="https://user-images.githubusercontent.com/6964699/190437655-69e27764-988f-477e-bfd6-d7f3f1205954.png">
