### PR TITLE
Add test that checks iterating through broadcast dims from the rightmost dim

### DIFF
--- a/tests/test_autograd_hw.py
+++ b/tests/test_autograd_hw.py
@@ -334,7 +334,7 @@ def test_broadcast_to_backward():
     gradient_check(ndl.broadcast_to, ndl.Tensor(np.random.randn(1,)), shape=(3, 3, 3))
     gradient_check(ndl.broadcast_to, ndl.Tensor(np.random.randn()), shape=(3, 3, 3))
     gradient_check(ndl.broadcast_to, ndl.Tensor(np.random.randn(5,4,1)), shape=(5,4,3))
-
+    gradient_check(ndl.broadcast_to, ndl.Tensor(np.random.randn(5)), shape=(1, 5))
 
 def test_summation_backward():
     gradient_check(ndl.summation, ndl.Tensor(np.random.randn(5,4)), axes=(1,))


### PR DESCRIPTION
As numpy docs state
> When operating on two arrays, NumPy compares their shapes element-wise. It starts with the **trailing (i.e. rightmost)** dimensions and works its way left

But _no of current tests_ (either local or mugrade one) actually checks that you're trying to find broadcast dims iterating from the right and not from left. 

I was able to pass all the tests in HW1, but failed on one of the Linear module's test in HW2 just because I'm iterating from the left. Particularly I'm using `zip_longest` to match the input dims and required dims. So for the` input_dim = (5,)` and `required_dim = (1, 5)` I'm dealing with `(5, None) and (1, 5)` instead of `(None, 5) and (1, 5)`. That's why I failed on the test. And that's why I suggest to add it in the HW1 :)