### PR TITLE
Removed redundant line in realize_cached_data()

### DIFF
--- a/python/needle/autograd.py
+++ b/python/needle/autograd.py
@@ -130,7 +130,6 @@ class Value:
         self.cached_data = self.op.compute(
             *[x.realize_cached_data() for x in self.inputs]
         )
-        self.cached_data
         return self.cached_data
 
     def is_leaf(self):


### PR DESCRIPTION
As noted by Tianqi Chen in the Lecture 5 ([timecode link](https://youtu.be/cNADlHfHQHg?t=2428)) and also mentioned in #4 the following line in `autograd.py` is redundant:
```python
self.cached_data
```

This PR removes this line