### PR TITLE
not trace the graph for non-require-grad tensors under eager mode 

### DIFF
--- a/python/needle/autograd.py
+++ b/python/needle/autograd.py
@@ -211,7 +211,7 @@ class TensorTuple(Value):
 
     def detach(self):
         """Create a new tensor that shares the data but detaches from the graph."""
-        return Tuple.make_const(self.realize_cached_data())
+        return TensorTuple.make_const(self.realize_cached_data())
 
 
 class Tensor(Value):
@@ -254,14 +254,6 @@ class Tensor(Value):
         if array_api is numpy:
             return numpy.array(numpy_array, dtype=dtype)
         return array_api.array(numpy_array, device=device, dtype=dtype)
-
-    @staticmethod
-    def make_from_op(op: Op, inputs: List["Value"]):
-        tensor = Tensor.__new__(Tensor)
-        tensor._init(op, inputs)
-        if not LAZY_MODE:
-            tensor.realize_cached_data()
-        return tensor
 
     @staticmethod
     def make_const(data, requires_grad=False):


### PR DESCRIPTION
I think the classmethod is a better implementation than the staticmethod since it takes care of `requires_grad`. If we are computing only non-require-grad tensors, they can be safely detached under the eager mode without tracing the graph.

demo for this pr:

```
In [1]: import sys

In [2]: sys.path.append('./python/')

In [3]: import needle as ndl

In [4]: a = ndl.Tensor([1.0], requires_grad=False)

In [5]: b = ndl.Tensor([1.0], requires_grad=False)

In [6]: c = a * b

In [7]: c.is_leaf()
Out[7]: True

In [8]: c.inputs
Out[8]: []

In [9]: c
Out[9]: needle.Tensor([1.])
```