### PR TITLE
fix typo

### DIFF
--- a/apps/simple_ml.py
+++ b/apps/simple_ml.py
@@ -58,7 +58,7 @@ def softmax_loss(Z, y_one_hot):
 def nn_epoch(X, y, W1, W2, lr = 0.1, batch=100):
     """ Run a single epoch of SGD for a two-layer neural network defined by the
     weights W1 and W2 (with no bias terms):
-        logits = ReLU(X * W1) * W1
+        logits = ReLU(X * W1) * W2
     The function should use the step size lr, and the specified batch size (and
     again, without randomizing the order of X).
 


### PR DESCRIPTION
Fix typo in Question 6.
Should be `logits = ReLU(X * W1) * W2` instead of `logits = ReLU(X * W1) * W1`